### PR TITLE
download_url should point to the public url

### DIFF
--- a/src/repository/models.py
+++ b/src/repository/models.py
@@ -817,7 +817,7 @@ class PreprintFile(models.Model):
 
     def download_url(self):
         return reverse(
-            'repository_download_file',
+            'repository_file_download',
             kwargs=self.reverse_kwargs(),
         )
 


### PR DESCRIPTION
repository_download_file is a manager only view whereas repository_file_download is a public view. Updating the download url so that OAI and JATS metadata contain correct public url for repository item. The download_url is used in OAI and JATS templates as well as in some emails. If the emails need to have manager only url, we can add additional download_url method in model to serve manager-only url. 